### PR TITLE
Responsive cart

### DIFF
--- a/resources/js/components/CartRestaurant.vue
+++ b/resources/js/components/CartRestaurant.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="cart-restaurant col-md-6 col-sm-12 mb-5">
+    <section class="cart-restaurant col-sm-12 col-md-9 mb-5">
         <div class="cart-container">
             <h4>Carrello</h4>
             <div class="cart">
@@ -149,7 +149,7 @@ export default {
         h3:first-child {
             flex-grow: 1;
         }
-        
+
     }
     }
     .payment {
@@ -164,7 +164,7 @@ export default {
         &:active {
             background-color: $secondary-400;
         }
-        
+
     }
 }
 

--- a/resources/js/pages/Restaurant.vue
+++ b/resources/js/pages/Restaurant.vue
@@ -1,12 +1,13 @@
 <template>
     <section class="restaurant">
+        <div class="container-fluid">
         <InfoRestaurant v-if="this.restaurant"
         :restaurantInfo="restaurant"
         />
         <p v-else>Loading...</p>
-        <div class="restaurant-container col-xs-12 col-md-9 mx-auto px-xs-3">
+        <div class="restaurant-container row">
                 <!-- <MenuRestaurant :plate="plate"/> -->
-            <div class="col-sm-12 col-md-6 plates_container">
+            <div class="col-sm-12 col-md-6 plates_container mb-4">
                 <CardRestaurant v-for="(plate, i) in plates" :key="`plate_${i}`"
                 v-show="plate.visibility"
                 :name="plate.name"
@@ -15,7 +16,10 @@
                 :plate="plate"
                 @click.native="toggleToCart(plate)"/>
             </div>
-            <CartRestaurant class="col-sm-12 col-md-6" :carrello="cart" />
+            <div class=" col-sm-12 col-md-6 ">
+                <CartRestaurant  :carrello="cart" />
+            </div>
+        </div>
         </div>
     </section>
 </template>
@@ -45,7 +49,7 @@ export default {
         this.getPlates();
         this.getRestaurant();
         this.getLocalStorage();
-        
+
     },
     mounted() {
         this.checkCartRestaurant();


### PR DESCRIPTION
In questo push per ora solo sistemato il responsive della pagina di pagamento dove il cart spariva, non dovrebbe sparire più sulla visualizzazione di dispositivi più piccoli